### PR TITLE
Task/CRM-78-Create-and-implement-base-DTO

### DIFF
--- a/src/main/java/com/sales_scout/dto/BaseDto.java
+++ b/src/main/java/com/sales_scout/dto/BaseDto.java
@@ -1,0 +1,28 @@
+package com.sales_scout.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BaseDto {
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private String createdBy;
+
+    private String updatedBy;
+
+
+
+}

--- a/src/main/java/com/sales_scout/dto/request/CommentRequestDto.java
+++ b/src/main/java/com/sales_scout/dto/request/CommentRequestDto.java
@@ -1,16 +1,18 @@
 package com.sales_scout.dto.request;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.enums.EntityEnum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class CommentRequestDto{
+@SuperBuilder
+public class CommentRequestDto extends BaseDto {
         private  EntityEnum entity;
         private String commentTxt;
         private  Long userId;

--- a/src/main/java/com/sales_scout/dto/request/CustomerRequestDto.java
+++ b/src/main/java/com/sales_scout/dto/request/CustomerRequestDto.java
@@ -1,6 +1,7 @@
 package com.sales_scout.dto.request;
 
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.Interest;
 import com.sales_scout.entity.data.*;
 import com.sales_scout.entity.leads.Prospect;
@@ -11,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -19,8 +21,8 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class CustomerRequestDto {
+@SuperBuilder
+public class CustomerRequestDto extends BaseDto {
     private Long id;
     private String logo;
     private String name;

--- a/src/main/java/com/sales_scout/dto/request/InterestRequestDto.java
+++ b/src/main/java/com/sales_scout/dto/request/InterestRequestDto.java
@@ -1,23 +1,24 @@
 package com.sales_scout.dto.request;
 
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.leads.Prospect;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
 import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class InterestRequestDto {
-
+@SuperBuilder
+public class InterestRequestDto extends BaseDto {
 
     private String name;
     private Boolean status;
     private Long companyId;
     private List<Prospect> prospects;
-
 }

--- a/src/main/java/com/sales_scout/dto/request/JwtRequest.java
+++ b/src/main/java/com/sales_scout/dto/request/JwtRequest.java
@@ -1,15 +1,17 @@
 package com.sales_scout.dto.request;
 
 
+import com.sales_scout.dto.BaseDto;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @ToString
-public class JwtRequest {
+public class JwtRequest extends BaseDto {
     private String email;
     private String password;
 

--- a/src/main/java/com/sales_scout/dto/request/ProspectInterestRequestDto.java
+++ b/src/main/java/com/sales_scout/dto/request/ProspectInterestRequestDto.java
@@ -1,17 +1,19 @@
 package com.sales_scout.dto.request;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.Interest;
 import com.sales_scout.entity.leads.Prospect;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
-@Builder
-public class ProspectInterestRequestDto {
+@SuperBuilder
+public class ProspectInterestRequestDto extends BaseDto {
 
 
     private String name;

--- a/src/main/java/com/sales_scout/dto/request/ProspectRequestDto.java
+++ b/src/main/java/com/sales_scout/dto/request/ProspectRequestDto.java
@@ -1,11 +1,11 @@
 package com.sales_scout.dto.request;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.Interest;
 import com.sales_scout.entity.data.*;
 import com.sales_scout.enums.ActiveInactiveEnum;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -14,8 +14,10 @@ import java.util.List;
 
 @Getter
 @Setter
-@Builder
-public class ProspectRequestDto {
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProspectRequestDto extends BaseDto {
     private Long id;
     private String logo;
     private String name;

--- a/src/main/java/com/sales_scout/dto/request/UserRequestDto.java
+++ b/src/main/java/com/sales_scout/dto/request/UserRequestDto.java
@@ -1,11 +1,12 @@
 package com.sales_scout.dto.request;
 
+import com.sales_scout.dto.BaseDto;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class UserRequestDto {
+public class UserRequestDto extends BaseDto {
         private String name;
         private String email;
         private String password;

--- a/src/main/java/com/sales_scout/dto/request/create/CompanyDepartmentRequestDTO.java
+++ b/src/main/java/com/sales_scout/dto/request/create/CompanyDepartmentRequestDTO.java
@@ -1,6 +1,7 @@
 package com.sales_scout.dto.request.create;
 
 
+import com.sales_scout.dto.BaseDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class CompanyDepartmentRequestDTO {
+public class CompanyDepartmentRequestDTO extends BaseDto {
     private Long id;
     @NotNull
     @NotBlank

--- a/src/main/java/com/sales_scout/dto/request/create/CreateCompanyDTO.java
+++ b/src/main/java/com/sales_scout/dto/request/create/CreateCompanyDTO.java
@@ -1,5 +1,6 @@
 package com.sales_scout.dto.request.create;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.data.*;
 import com.sales_scout.enums.ActiveInactiveEnum;
 import jakarta.persistence.Column;
@@ -16,7 +17,7 @@ import java.util.Date;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateCompanyDTO  {
+public class CreateCompanyDTO extends BaseDto {
     private Long id;
     private String logo;
     private String name;
@@ -40,11 +41,7 @@ public class CreateCompanyDTO  {
     private String certificationText;
     private String businessDescription;
     private ActiveInactiveEnum status;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
-    private String createdBy;
-    private String updatedBy;
     // Nested DTOs
     private LegalStatus legalStatus;
     private City city;

--- a/src/main/java/com/sales_scout/dto/request/create/CreateInterlocutorDTO.java
+++ b/src/main/java/com/sales_scout/dto/request/create/CreateInterlocutorDTO.java
@@ -2,6 +2,7 @@ package com.sales_scout.dto.request.create;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sales_scout.deserializer.ActiveInactiveEnumDeserializer;
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.data.EmailAddress;
 import com.sales_scout.entity.data.PhoneNumber;
 import com.sales_scout.enums.ActiveInactiveEnum;
@@ -10,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class CreateInterlocutorDTO {
+public class CreateInterlocutorDTO extends BaseDto {
 
     @NotBlank(message = "Full name is required.")
     private String fullName;

--- a/src/main/java/com/sales_scout/dto/request/create/CreateProjectDto.java
+++ b/src/main/java/com/sales_scout/dto/request/create/CreateProjectDto.java
@@ -1,12 +1,13 @@
 package com.sales_scout.dto.request.create;
 
+import com.sales_scout.dto.BaseDto;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
 
 @Setter
 @Getter
-public class CreateProjectDto {
+public class CreateProjectDto extends BaseDto {
 
     @NotBlank(message = "Le nom ne doit pas être vide")
     @Size(max = 100, message = "Le nom du projet ne peut pas dépasser 100 caractères.")

--- a/src/main/java/com/sales_scout/dto/request/create/InteractionRequestDto.java
+++ b/src/main/java/com/sales_scout/dto/request/create/InteractionRequestDto.java
@@ -1,15 +1,21 @@
 package com.sales_scout.dto.request.create;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.enums.InteractionSubject;
 import com.sales_scout.enums.InteractionType;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Data
-@Builder
-public class InteractionRequestDto {
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+public class InteractionRequestDto extends BaseDto {
     private Long prospectId;
     private Long interlocutorId;
     private String report;

--- a/src/main/java/com/sales_scout/dto/request/create/JwtRequest.java
+++ b/src/main/java/com/sales_scout/dto/request/create/JwtRequest.java
@@ -1,15 +1,17 @@
 package com.sales_scout.dto.request.create;
 
 
+import com.sales_scout.dto.BaseDto;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @ToString
-public class JwtRequest {
+public class JwtRequest extends BaseDto {
     private String email;
     private String password;
 

--- a/src/main/java/com/sales_scout/dto/request/create/LoginUserDto.java
+++ b/src/main/java/com/sales_scout/dto/request/create/LoginUserDto.java
@@ -1,10 +1,11 @@
 package com.sales_scout.dto.request.create;
 
 
+import com.sales_scout.dto.BaseDto;
 import lombok.Data;
 
 @Data
-public class LoginUserDto {
+public class LoginUserDto extends BaseDto {
     private String email;
 
     private String password;

--- a/src/main/java/com/sales_scout/dto/request/create/RegisterUserDto.java
+++ b/src/main/java/com/sales_scout/dto/request/create/RegisterUserDto.java
@@ -1,11 +1,12 @@
 package com.sales_scout.dto.request.create;
 
+import com.sales_scout.dto.BaseDto;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class RegisterUserDto  {
+public class RegisterUserDto extends BaseDto {
 
         private String email;
 

--- a/src/main/java/com/sales_scout/dto/request/create/StorageNeedCreateDto.java
+++ b/src/main/java/com/sales_scout/dto/request/create/StorageNeedCreateDto.java
@@ -1,5 +1,6 @@
 package com.sales_scout.dto.request.create;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.enums.crm.wms.LivreEnum;
 import com.sales_scout.enums.crm.wms.NeedStatusEnum;
 import com.sales_scout.enums.crm.wms.StorageReasonEnum;
@@ -9,7 +10,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import java.time.LocalDateTime;
 
-public class StorageNeedCreateDto {
+public class StorageNeedCreateDto extends BaseDto {
 
         @NotNull(message = "Reference UUID is required")
         private UUID ref;

--- a/src/main/java/com/sales_scout/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/CommentResponseDto.java
@@ -1,21 +1,21 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.enums.EntityEnum;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class CommentResponseDto {
+@SuperBuilder
+public class CommentResponseDto extends BaseDto {
     private Long id;
     private String commentTxt;
     private Long userId; // ID of the user who created the comment.
     private String userName; // Optional: User's name for display purposes.
     private EntityEnum entity; // The module name (e.g., "Invoice", "Customer").
     private Long entityId; // The ID of the associated entity.
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/sales_scout/dto/response/CompanyResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/CompanyResponseDto.java
@@ -1,8 +1,10 @@
 package com.sales_scout.dto.response;
 
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.data.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Date;
 
@@ -11,8 +13,8 @@ import java.util.Date;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class CompanyResponseDto {
+@SuperBuilder
+public class CompanyResponseDto extends BaseDto {
     private Long id;
     private String logo;
     private String name;

--- a/src/main/java/com/sales_scout/dto/response/CustomerResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/CustomerResponseDto.java
@@ -1,11 +1,13 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.Interest;
 import com.sales_scout.entity.data.*;
 import com.sales_scout.entity.leads.TrackingLog;
 import com.sales_scout.enums.ActiveInactiveEnum;
 import com.sales_scout.enums.ProspectStatus;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -16,8 +18,8 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class CustomerResponseDto {
+@SuperBuilder
+public class CustomerResponseDto extends BaseDto {
     private Long id;
     private String logo;
     private String name;

--- a/src/main/java/com/sales_scout/dto/response/InteractionResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/InteractionResponseDto.java
@@ -1,19 +1,21 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.enums.InteractionSubject;
 import com.sales_scout.enums.InteractionType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class InteractionResponseDto {
+public class InteractionResponseDto extends BaseDto {
     private Long id;
     private Long prospectId;
     private String prospectName;
@@ -30,5 +32,4 @@ public class InteractionResponseDto {
     private String agentName;
     private Long affectedToId;
     private String affectedToName;
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/sales_scout/dto/response/InterestResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/InterestResponseDto.java
@@ -1,17 +1,18 @@
 package com.sales_scout.dto.response;
 
 
+import com.sales_scout.dto.BaseDto;
 import lombok.*;
-
+import lombok.experimental.SuperBuilder;
 
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Getter
 @Setter
-public class InterestResponseDto {
+public class InterestResponseDto extends BaseDto {
     private Long id;
     private String name;
     private Boolean status;

--- a/src/main/java/com/sales_scout/dto/response/InterlocutorResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/InterlocutorResponseDto.java
@@ -1,5 +1,6 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.data.Department;
 import com.sales_scout.entity.data.EmailAddress;
 import com.sales_scout.entity.data.JobTitle;
@@ -8,11 +9,12 @@ import com.sales_scout.enums.ActiveInactiveEnum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
-@Builder
+@SuperBuilder
 @Data
 @AllArgsConstructor
-public class InterlocutorResponseDto {
+public class InterlocutorResponseDto extends BaseDto {
     private Long id;
     private String fullName;
 

--- a/src/main/java/com/sales_scout/dto/response/JwtResponse.java
+++ b/src/main/java/com/sales_scout/dto/response/JwtResponse.java
@@ -1,14 +1,16 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @ToString
-@Builder
-public class JwtResponse {
+@SuperBuilder
+public class JwtResponse extends BaseDto {
     public String token;
     public UserDetails userResponseDto;
 

--- a/src/main/java/com/sales_scout/dto/response/ProspectInterestResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/ProspectInterestResponseDto.java
@@ -1,18 +1,20 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.Interest;
 import com.sales_scout.entity.leads.Prospect;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 
-public class ProspectInterestResponseDto {
+public class ProspectInterestResponseDto extends BaseDto {
 
     private Long id;
 

--- a/src/main/java/com/sales_scout/dto/response/ProspectResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/ProspectResponseDto.java
@@ -1,5 +1,6 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.Interest;
 import com.sales_scout.entity.data.*;
 import com.sales_scout.entity.leads.ProspectInterest;
@@ -8,6 +9,7 @@ import com.sales_scout.enums.ProspectStatus;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -16,8 +18,8 @@ import java.util.List;
 
 @Getter
 @Setter
-@Builder
-public class ProspectResponseDto {
+@SuperBuilder
+public class ProspectResponseDto extends BaseDto {
     private Long id;
     private String logo;
     private String name;

--- a/src/main/java/com/sales_scout/dto/response/TrackingLogForProspect.java
+++ b/src/main/java/com/sales_scout/dto/response/TrackingLogForProspect.java
@@ -1,14 +1,17 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 
 @Builder
-@Getter @Setter
+@Getter
+@Setter
 public class TrackingLogForProspect {
     private Long id;
     private String actionType; // e.g., CREATE, UPDATE, DELETE, VIEW

--- a/src/main/java/com/sales_scout/dto/response/UserResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/UserResponseDto.java
@@ -1,17 +1,19 @@
 package com.sales_scout.dto.response;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.entity.Right;
 import com.sales_scout.entity.Role;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserResponseDto {
+public class UserResponseDto extends BaseDto {
     private String name;
     private String email;
 //    private String password;

--- a/src/main/java/com/sales_scout/dto/response/crm/wms/CustomerDto.java
+++ b/src/main/java/com/sales_scout/dto/response/crm/wms/CustomerDto.java
@@ -1,6 +1,8 @@
 package com.sales_scout.dto.response.crm.wms;
 
-public class CustomerDto {
+import com.sales_scout.dto.BaseDto;
+
+public class CustomerDto extends BaseDto {
     private Long id;
     private String name; // Add more customer fields if needed
 

--- a/src/main/java/com/sales_scout/dto/response/crm/wms/StorageNeedResponseDto.java
+++ b/src/main/java/com/sales_scout/dto/response/crm/wms/StorageNeedResponseDto.java
@@ -1,9 +1,11 @@
 package com.sales_scout.dto.response.crm.wms;
 
+import com.sales_scout.dto.BaseDto;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public class StorageNeedResponseDto {
+public class StorageNeedResponseDto extends BaseDto {
     private Long id;
     private UUID ref;
     private String liverStatus;  // LivreEnum as String

--- a/src/main/java/com/sales_scout/dto/response/leads_dashboard/CountsDto.java
+++ b/src/main/java/com/sales_scout/dto/response/leads_dashboard/CountsDto.java
@@ -1,14 +1,17 @@
 package com.sales_scout.dto.response.leads_dashboard;
 
+import com.sales_scout.dto.BaseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder @Data
-public class CountsDto {
+@SuperBuilder
+@Data
+public class CountsDto extends BaseDto {
     private Long countOfProspects;
     private Long CountOfInteractions;
     private Long CountOfInterlocutors;

--- a/src/main/java/com/sales_scout/dto/response/leads_dashboard/InteractionCountDto.java
+++ b/src/main/java/com/sales_scout/dto/response/leads_dashboard/InteractionCountDto.java
@@ -1,11 +1,12 @@
 package com.sales_scout.dto.response.leads_dashboard;
 
+import com.sales_scout.dto.BaseDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class InteractionCountDto {
+public class InteractionCountDto extends BaseDto {
     private String type; // Interaction type (e.g., email, call, meeting)
     private Long count;  // Count of interactions
 }

--- a/src/main/java/com/sales_scout/dto/response/leads_dashboard/ProspectCountDto.java
+++ b/src/main/java/com/sales_scout/dto/response/leads_dashboard/ProspectCountDto.java
@@ -1,11 +1,12 @@
 package com.sales_scout.dto.response.leads_dashboard;
 
+import com.sales_scout.dto.BaseDto;
 import com.sales_scout.enums.ProspectStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-public class ProspectCountDto {
+public class ProspectCountDto extends BaseDto {
     private ProspectStatus status;
     private Long count;
 

--- a/src/main/java/com/sales_scout/entity/BaseEntity.java
+++ b/src/main/java/com/sales_scout/entity/BaseEntity.java
@@ -5,8 +5,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.LocalDateTime;
@@ -14,6 +17,9 @@ import java.time.LocalDateTime;
 @Setter
 @Getter
 @MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
 public abstract class BaseEntity {
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/sales_scout/entity/Comment.java
+++ b/src/main/java/com/sales_scout/entity/Comment.java
@@ -3,13 +3,14 @@ package com.sales_scout.entity;
 import com.sales_scout.enums.EntityEnum;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Table(name = "comments")
 public class Comment extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/Company.java
+++ b/src/main/java/com/sales_scout/entity/Company.java
@@ -6,6 +6,7 @@ import com.sales_scout.entity.leads.Prospect;
 import com.sales_scout.enums.ActiveInactiveEnum;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.*;
 
@@ -14,7 +15,7 @@ import java.util.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter @Setter
-@Builder
+@SuperBuilder
 @Table(name = "companies")
 public class Company extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/Customer.java
+++ b/src/main/java/com/sales_scout/entity/Customer.java
@@ -9,6 +9,7 @@ import com.sales_scout.enums.ActiveInactiveEnum;
 import com.sales_scout.enums.ProspectStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.*;
 
@@ -16,7 +17,7 @@ import java.util.*;
 @Table(name = "customers")
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Customer extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/Interest.java
+++ b/src/main/java/com/sales_scout/entity/Interest.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,7 +16,8 @@ import java.util.List;
 @Entity
 @Table(name = "interests")
 @AllArgsConstructor @NoArgsConstructor
-@Builder @Data
+@SuperBuilder
+@Data
 public class Interest extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sales_scout/entity/Right.java
+++ b/src/main/java/com/sales_scout/entity/Right.java
@@ -2,13 +2,14 @@ package com.sales_scout.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Getter @Setter
 @Table(name = "rights")
 public class Right extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/Role.java
+++ b/src/main/java/com/sales_scout/entity/Role.java
@@ -2,6 +2,7 @@ package com.sales_scout.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
@@ -9,7 +10,7 @@ import java.util.List;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Getter @Setter
 @Table(name = "roles")
 public class Role extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/UserEntity.java
+++ b/src/main/java/com/sales_scout/entity/UserEntity.java
@@ -4,6 +4,7 @@ package com.sales_scout.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
@@ -15,7 +16,7 @@ import java.util.Set;
 @NoArgsConstructor
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @Table (name = "users")
 public class UserEntity extends BaseEntity implements UserDetails {
         @Id

--- a/src/main/java/com/sales_scout/entity/Workspace.java
+++ b/src/main/java/com/sales_scout/entity/Workspace.java
@@ -2,6 +2,7 @@ package com.sales_scout.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
@@ -9,7 +10,7 @@ import java.util.List;
 @Table(name = "workspaces")
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Workspace extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/crm/wms/Dimension.java
+++ b/src/main/java/com/sales_scout/entity/crm/wms/Dimension.java
@@ -3,6 +3,7 @@ package com.sales_scout.entity.crm.wms;
 import com.sales_scout.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 
@@ -11,7 +12,7 @@ import java.util.Set;
 @Table(name = "dimensions")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Data
 public class Dimension extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/crm/wms/StackedLevel.java
+++ b/src/main/java/com/sales_scout/entity/crm/wms/StackedLevel.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 import java.util.UUID;
@@ -14,7 +15,7 @@ import java.util.UUID;
 @Table(name = "stacked_levels")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Data
 public class StackedLevel extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/crm/wms/StockedItem.java
+++ b/src/main/java/com/sales_scout/entity/crm/wms/StockedItem.java
@@ -3,6 +3,7 @@ package com.sales_scout.entity.crm.wms;
 import com.sales_scout.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.UUID;
 
@@ -11,7 +12,7 @@ import java.util.UUID;
 @Table(name = "stocked_items")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Data
 public class StockedItem extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/crm/wms/StorageNeed.java
+++ b/src/main/java/com/sales_scout/entity/crm/wms/StorageNeed.java
@@ -7,6 +7,7 @@ import com.sales_scout.enums.crm.wms.NeedStatusEnum;
 import com.sales_scout.enums.crm.wms.StorageReasonEnum;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -15,7 +16,7 @@ import java.util.UUID;
 @Table(name = "storage_needs")
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class StorageNeed extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/crm/wms/Structure.java
+++ b/src/main/java/com/sales_scout/entity/crm/wms/Structure.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 import java.util.UUID;
@@ -14,7 +15,7 @@ import java.util.UUID;
 @Table(name = "structures")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Data
 public class Structure extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/crm/wms/Support.java
+++ b/src/main/java/com/sales_scout/entity/crm/wms/Support.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 import java.util.UUID;
@@ -15,7 +16,8 @@ import java.util.UUID;
 @Table(name = "supports")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder @Data
+@SuperBuilder
+@Data
 public class Support  extends BaseEntity {
 
     @Id

--- a/src/main/java/com/sales_scout/entity/crm/wms/Temperature.java
+++ b/src/main/java/com/sales_scout/entity/crm/wms/Temperature.java
@@ -3,6 +3,7 @@ package com.sales_scout.entity.crm.wms;
 import com.sales_scout.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 import java.util.UUID;
@@ -12,7 +13,7 @@ import java.util.UUID;
 @Table(name = "temperatures")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Data
 public class Temperature extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/data/EmailAddress.java
+++ b/src/main/java/com/sales_scout/entity/data/EmailAddress.java
@@ -4,11 +4,12 @@ import com.sales_scout.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "email_addresses")
 @Getter @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class EmailAddress extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/leads/Interaction.java
+++ b/src/main/java/com/sales_scout/entity/leads/Interaction.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
 @Table(name = "interactions")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Data
 public class Interaction extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/leads/Interlocutor.java
+++ b/src/main/java/com/sales_scout/entity/leads/Interlocutor.java
@@ -11,12 +11,13 @@ import com.sales_scout.enums.ActiveInactiveEnum;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "interlocutors")
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Getter @Setter
 public class Interlocutor extends BaseEntity {
     @Id

--- a/src/main/java/com/sales_scout/entity/leads/Prospect.java
+++ b/src/main/java/com/sales_scout/entity/leads/Prospect.java
@@ -9,6 +9,7 @@ import com.sales_scout.enums.ActiveInactiveEnum;
 import com.sales_scout.enums.ProspectStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.*;
 
@@ -16,7 +17,7 @@ import java.util.*;
 @Entity
 @Table(name = "prospects")
 @Getter @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Prospect extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/leads/ProspectInterest.java
+++ b/src/main/java/com/sales_scout/entity/leads/ProspectInterest.java
@@ -6,6 +6,7 @@ import com.sales_scout.entity.BaseEntity;
 import com.sales_scout.entity.Interest;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.*;
 
@@ -13,7 +14,7 @@ import java.util.*;
 @Entity
 @Table(name = "prospectInterest")
 @Getter @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProspectInterest extends BaseEntity {

--- a/src/main/java/com/sales_scout/entity/leads/TrackingLog.java
+++ b/src/main/java/com/sales_scout/entity/leads/TrackingLog.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/sales_scout/mapper/CompanyDtoBuilder.java
+++ b/src/main/java/com/sales_scout/mapper/CompanyDtoBuilder.java
@@ -5,7 +5,6 @@ import com.sales_scout.dto.request.create.CreateCompanyDTO;
 import com.sales_scout.dto.response.CompanyResponseDto;
 import com.sales_scout.entity.Company;
 
-import java.util.List;
 
 public class CompanyDtoBuilder {
 
@@ -45,6 +44,10 @@ public class CompanyDtoBuilder {
                 .proprietaryStructure(company.getProprietaryStructure())
                 .title(company.getTitle())
                 .reprosentaveJobTitle(company.getReprosentaveJobTitle())
+                .createdAt(company.getCreatedAt())
+                .createdBy(company.getCreatedBy())
+                .updatedAt(company.getUpdatedAt())
+                .updatedBy(company.getUpdatedBy())
                 .build();
     }
 
@@ -52,9 +55,6 @@ public class CompanyDtoBuilder {
         if(createCompanyDTO == null){
             return null;
         }
-
-
-
         return Company.builder()
                 .logo(imagePath)
                 .name(createCompanyDTO.getName())
@@ -85,7 +85,10 @@ public class CompanyDtoBuilder {
                 .proprietaryStructure(createCompanyDTO.getProprietaryStructure())
                 .title(createCompanyDTO.getTitle())
                 .reprosentaveJobTitle(createCompanyDTO.getReprosentaveJobTitle())
+                .createdAt(createCompanyDTO.getCreatedAt())
+                .createdBy(createCompanyDTO.getCreatedBy())
+                .updatedAt(createCompanyDTO.getUpdatedAt())
+                .updatedBy(createCompanyDTO.getUpdatedBy())
                 .build();
-
     }
 }

--- a/src/main/java/com/sales_scout/mapper/CustomerMapper.java
+++ b/src/main/java/com/sales_scout/mapper/CustomerMapper.java
@@ -49,6 +49,10 @@ public class CustomerMapper {
                 .interest(customer.getInterest())
                 .prospectId(customer.getProspect().getId())
                 .companyId(customer.getCompany().getId())
+                .createdAt(customer.getCreatedAt())
+                .createdBy(customer.getCreatedBy())
+                .updatedAt(customer.getUpdatedAt())
+                .updatedBy(customer.getUpdatedBy())
                 .build();
     }
 
@@ -93,6 +97,10 @@ public class CustomerMapper {
                 .trackingLogs(customerDetails.getTrackingLogs())
                 .interest(customerDetails.getInterest())
                 .prospect(Prospect.builder().id(customerDetails.getProspectId()).build())
+                .createdAt(customerDetails.getCreatedAt())
+                .createdBy(customerDetails.getCreatedBy())
+                .updatedAt(customerDetails.getUpdatedAt())
+                .updatedBy(customerDetails.getUpdatedBy())
                 .build();
     }
 }

--- a/src/main/java/com/sales_scout/mapper/InterestDtoBuilder.java
+++ b/src/main/java/com/sales_scout/mapper/InterestDtoBuilder.java
@@ -14,6 +14,10 @@ public class InterestDtoBuilder {
                 .name(interest.getName())
                 .status(interest.getStatus())
                 .companyId(interest.getCompany().getId())
+                .createdAt(interest.getCreatedAt())
+                .createdBy(interest.getCreatedBy())
+                .updatedAt(interest.getUpdatedAt())
+                .updatedBy(interest.getUpdatedBy())
                 .build();
     }
 

--- a/src/main/java/com/sales_scout/mapper/ProspectInterestDtoBuilder.java
+++ b/src/main/java/com/sales_scout/mapper/ProspectInterestDtoBuilder.java
@@ -15,6 +15,10 @@ public class ProspectInterestDtoBuilder {
                 .status(prospectInterest.getStatus())
                 .prospectId(prospectInterest.getProspect().getId())
                 .interestId(prospectInterest.getInterest().getId())
+                .createdAt(prospectInterest.getCreatedAt())
+                .createdBy(prospectInterest.getCreatedBy())
+                .updatedAt(prospectInterest.getUpdatedAt())
+                .updatedBy(prospectInterest.getUpdatedBy())
                 .build();
     }
     public static ProspectInterest fromDto(ProspectInterestRequestDto prospectInterestRequestDto){
@@ -23,6 +27,10 @@ public class ProspectInterestDtoBuilder {
                 .status(prospectInterestRequestDto.getStatus())
                 .prospect(Prospect.builder().id(prospectInterestRequestDto.getProspectId()).build())
                 .interest(Interest.builder().id(prospectInterestRequestDto.getInterestId()).build())
+                .createdAt(prospectInterestRequestDto.getCreatedAt())
+                .createdBy(prospectInterestRequestDto.getCreatedBy())
+                .updatedAt(prospectInterestRequestDto.getUpdatedAt())
+                .updatedBy(prospectInterestRequestDto.getUpdatedBy())
                 .build();
     }
 }

--- a/src/main/java/com/sales_scout/mapper/ProspectResponseDtoBuilder.java
+++ b/src/main/java/com/sales_scout/mapper/ProspectResponseDtoBuilder.java
@@ -63,13 +63,16 @@ public class ProspectResponseDtoBuilder {
                 .reprosentaveJobTitle(prospect.getReprosentaveJobTitle()) // Add mapping if needed
                 .logo(prospect.getLogo())
                 .trackingLogs(trackingLogForProspects)
-
                 .interest(
                         prospect.getProspectInterests().stream()
-                                .filter(prospectInterest -> prospectInterest.getInterest() != null) // تأكد من أن الـ Interest ليس null
-                                .map(prospectInterest -> InterestDtoBuilder.fromEntity(prospectInterest.getInterest())) // تحويل Interest إلى InterestDto
+                                .filter(prospectInterest -> prospectInterest.getInterest() != null)
+                                .map(prospectInterest -> InterestDtoBuilder.fromEntity(prospectInterest.getInterest()))
                                 .toList()
                 )
+                .createdAt(prospect.getCreatedAt())
+                .createdBy(prospect.getCreatedBy())
+                .updatedAt(prospect.getUpdatedAt())
+                .updatedBy(prospect.getUpdatedBy())
                 .build();
     }
 }

--- a/src/main/java/com/sales_scout/mapper/StorageNeedMapper.java
+++ b/src/main/java/com/sales_scout/mapper/StorageNeedMapper.java
@@ -30,6 +30,10 @@ public class StorageNeedMapper {
         storageNeed.setDuration(dto.getDuration());
         storageNeed.setNumberOfSku(dto.getNumberOfSku());
         storageNeed.setProductType(dto.getProductType());
+        storageNeed.setCreatedAt(dto.getCreatedAt());
+        storageNeed.setCreatedBy(dto.getCreatedBy());
+        storageNeed.setUpdatedAt(dto.getUpdatedAt());
+        storageNeed.setUpdatedBy(dto.getUpdatedBy());
 
         // Set the customer entity by ID (assumes a customer service or repository fetch)
         Customer customer = new Customer();
@@ -55,6 +59,10 @@ public class StorageNeedMapper {
         dto.setDuration(storageNeed.getDuration());
         dto.setNumberOfSku(storageNeed.getNumberOfSku());
         dto.setProductType(storageNeed.getProductType());
+        dto.setCreatedAt(storageNeed.getCreatedAt());
+        dto.setCreatedBy(storageNeed.getCreatedBy());
+        dto.setUpdatedAt(storageNeed.getUpdatedAt());
+        dto.setUpdatedBy(storageNeed.getUpdatedBy());
 
         // Map nested customer details
         if (storageNeed.getCustomer() != null) {

--- a/src/main/java/com/sales_scout/service/leads/InteractionService.java
+++ b/src/main/java/com/sales_scout/service/leads/InteractionService.java
@@ -107,6 +107,10 @@ public class InteractionService {
                 .planningDate(interactionRequestDto.getPlanningDate())
                 .joinFilePath(interactionRequestDto.getJoinFilePath())
                 .address(interactionRequestDto.getAddress())
+                .createdAt(interactionRequestDto.getCreatedAt())
+                .createdBy(interactionRequestDto.getCreatedBy())
+                .updatedAt(interactionRequestDto.getUpdatedAt())
+                .updatedBy(interactionRequestDto.getUpdatedBy())
                 .build();
 
         // Save the interaction entity
@@ -164,6 +168,9 @@ public class InteractionService {
                 .affectedToId(interaction.getAffectedTo() != null  ?  interaction.getAffectedTo().getId() : null)
                 .affectedToName(interaction.getAffectedTo() != null ? interaction.getAffectedTo().getName() : null)
                 .createdAt(interaction.getCreatedAt())
+                .createdBy(interaction.getCreatedBy())
+                .updatedAt(interaction.getUpdatedAt())
+                .updatedBy(interaction.getUpdatedBy())
                 .agentName(interaction.getAgent().getName())
                 .build();
     }

--- a/src/main/java/com/sales_scout/service/leads/InterlocutorService.java
+++ b/src/main/java/com/sales_scout/service/leads/InterlocutorService.java
@@ -4,6 +4,7 @@ import com.sales_scout.dto.request.create.CreateInterlocutorDTO;
 import com.sales_scout.dto.request.update.UpdateInterlocutorDto;
 import com.sales_scout.dto.response.InterlocutorResponseDto;
 import com.sales_scout.dto.response.ProspectResponseDto;
+import com.sales_scout.entity.UserEntity;
 import com.sales_scout.entity.leads.Interlocutor;
 import com.sales_scout.entity.leads.Prospect;
 import com.sales_scout.entity.data.Department;
@@ -17,30 +18,32 @@ import com.sales_scout.repository.leads.InterlocutorRepository;
 import com.sales_scout.repository.PhoneNumberRepository;
 import com.sales_scout.repository.leads.ProspectRepository;
 import com.sales_scout.repository.data.JobTitleRepository;
+import com.sales_scout.service.AuthenticationService;
 import com.sales_scout.service.data.DepartmentService;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 public class InterlocutorService {
     private final InterlocutorRepository interlocutorRepository;
-    private final ProspectService prospectService;
     private final DepartmentService departmentService;
     final private EmailAddressRepository emailAddressRepository;
     final private PhoneNumberRepository phoneNumberRepository;
     private final JobTitleRepository jobTitleRepository;
     private final ProspectRepository prospectRepository;
-    public InterlocutorService(InterlocutorRepository interlocutorRepository, ProspectService prospectService, DepartmentService departmentService, EmailAddressRepository emailAddressRepository, PhoneNumberRepository phoneNumberRepository, JobTitleRepository jobTitleRepository, ProspectRepository prospectRepository) {
+    private  final AuthenticationService authenticationService;
+    public InterlocutorService(InterlocutorRepository interlocutorRepository, DepartmentService departmentService, EmailAddressRepository emailAddressRepository, PhoneNumberRepository phoneNumberRepository, JobTitleRepository jobTitleRepository, ProspectRepository prospectRepository, AuthenticationService authenticationService) {
         this.interlocutorRepository = interlocutorRepository;
-        this.prospectService = prospectService;
         this.departmentService = departmentService;
         this.emailAddressRepository = emailAddressRepository;
         this.phoneNumberRepository = phoneNumberRepository;
         this.jobTitleRepository = jobTitleRepository;
         this.prospectRepository = prospectRepository;
+        this.authenticationService = authenticationService;
     }
 
     /**
@@ -52,15 +55,19 @@ public class InterlocutorService {
         return  interlocutors.stream().map(interlocutor -> {
             ProspectResponseDto prospectresponseDto = ProspectResponseDtoBuilder.fromEntity(interlocutor.getProspect());
             return InterlocutorResponseDto.builder()
-                     .fullName(interlocutor.getFullName())
-                     .id(interlocutor.getId())
-                     .department(interlocutor.getDepartment())
-                     .phoneNumber(interlocutor.getPhoneNumber())
-                     .emailAddress(interlocutor.getEmailAddress())
-                     .prospect(prospectresponseDto)
-                     .jobTitle(interlocutor.getJobTitle())
-                     .active(interlocutor.getActive())
-                     .build();
+                    .fullName(interlocutor.getFullName())
+                    .id(interlocutor.getId())
+                    .department(interlocutor.getDepartment())
+                    .phoneNumber(interlocutor.getPhoneNumber())
+                    .emailAddress(interlocutor.getEmailAddress())
+                    .prospect(prospectresponseDto)
+                    .jobTitle(interlocutor.getJobTitle())
+                    .active(interlocutor.getActive())
+                    .createdAt(interlocutor.getCreatedAt())
+                    .createdBy(interlocutor.getCreatedBy())
+                    .updatedAt(interlocutor.getUpdatedAt())
+                    .updatedBy(interlocutor.getUpdatedBy())
+                    .build();
         }).collect(Collectors.toList());
     }
 
@@ -71,8 +78,10 @@ public class InterlocutorService {
      */
     public List<InterlocutorResponseDto> getInterlocutorsByProspectId(Long prospectId) {
         List<Interlocutor> interlocutors = this.interlocutorRepository.findAllByProspectId(prospectId);
+
         return  interlocutors.stream().map(interlocutor -> {
             ProspectResponseDto prospectresponseDto = ProspectResponseDtoBuilder.fromEntity(interlocutor.getProspect());
+
             return InterlocutorResponseDto.builder()
                     .fullName(interlocutor.getFullName())
                     .id(interlocutor.getId())
@@ -82,6 +91,10 @@ public class InterlocutorService {
                     .prospect(prospectresponseDto)
                     .jobTitle(interlocutor.getJobTitle())
                     .active(interlocutor.getActive())
+                    .createdAt(interlocutor.getCreatedAt())
+                    .createdBy(interlocutor.getCreatedBy())
+                    .updatedAt(interlocutor.getUpdatedAt())
+                    .updatedBy(interlocutor.getUpdatedBy())
                     .build();
         }).collect(Collectors.toList());
     }
@@ -125,6 +138,8 @@ public class InterlocutorService {
         emailAddress.setAddress(interlocutorDto.getEmailAddress().getAddress()); // Correct field
         emailAddress = this.emailAddressRepository.save(emailAddress);
 
+        UserEntity user = this.authenticationService.getCurrentUser();
+
         // Build Interlocutor
         Interlocutor interlocutor = Interlocutor.builder()
                 .fullName(interlocutorDto.getFullName())
@@ -134,8 +149,9 @@ public class InterlocutorService {
                 .department(department)
                 .jobTitle(jobTitle)
                 .active(ActiveInactiveEnum.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .createdBy(user.getName())
                 .build();
-
         // Save and return
         return interlocutorRepository.save(interlocutor);
     }
@@ -173,6 +189,7 @@ public class InterlocutorService {
                     return phoneNumberRepository.save(newPhoneNumber);
                 });
 
+        UserEntity user = this.authenticationService.getCurrentUser();
 
         // Fetch existing Interlocutor
         Interlocutor interlocutor = interlocutorRepository.findByDeletedAtIsNullAndId(updateInterlocutorDto.getId())
@@ -185,6 +202,8 @@ public class InterlocutorService {
         interlocutor.setPhoneNumber(phoneNumber); // Use persisted PhoneNumber
         interlocutor.setJobTitle(jobTitle);
         interlocutor.setActive(updateInterlocutorDto.getActive());
+        interlocutor.setUpdatedAt(LocalDateTime.now());
+        interlocutor.setUpdatedBy(user.getName());
 
         // Save and return
         return interlocutorRepository.save(interlocutor);
@@ -205,9 +224,12 @@ public class InterlocutorService {
                 .phoneNumber(interlocutor.getPhoneNumber())
                 .emailAddress(interlocutor.getEmailAddress())
                 .active(interlocutor.getActive())
+                .createdAt(interlocutor.getCreatedAt())
+                .createdBy(interlocutor.getCreatedBy())
+                .updatedAt(interlocutor.getUpdatedAt())
+                .updatedBy(interlocutor.getUpdatedBy())
                 .build();
     }
-
 
     /**
      * Soft delete an interlocutor by ID

--- a/src/main/java/com/sales_scout/service/leads/ProspectInterestService.java
+++ b/src/main/java/com/sales_scout/service/leads/ProspectInterestService.java
@@ -3,16 +3,18 @@ package com.sales_scout.service.leads;
 import com.sales_scout.dto.request.ProspectInterestRequestDto;
 import com.sales_scout.dto.response.ProspectInterestResponseDto;
 import com.sales_scout.entity.Interest;
+import com.sales_scout.entity.UserEntity;
 import com.sales_scout.entity.leads.Prospect;
 import com.sales_scout.entity.leads.ProspectInterest;
 import com.sales_scout.mapper.ProspectInterestDtoBuilder;
 import com.sales_scout.repository.InterestRepository;
 import com.sales_scout.repository.leads.ProspectInterestRepository;
 import com.sales_scout.repository.leads.ProspectRepository;
+import com.sales_scout.service.AuthenticationService;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -20,11 +22,12 @@ public class ProspectInterestService {
     private final ProspectInterestRepository prospectInterestRepository;
     private final ProspectRepository prospectRepository;
     private final InterestRepository interestRepository;
-
-    public ProspectInterestService(ProspectInterestRepository prospectInterestRepository, ProspectRepository prospectRepository, InterestRepository interestRepository) {
+    private final AuthenticationService authenticationService;
+    public ProspectInterestService(ProspectInterestRepository prospectInterestRepository, ProspectRepository prospectRepository, InterestRepository interestRepository, AuthenticationService authenticationService) {
         this.prospectInterestRepository = prospectInterestRepository;
         this.prospectRepository = prospectRepository;
         this.interestRepository = interestRepository;
+        this.authenticationService = authenticationService;
     }
 
 
@@ -45,11 +48,14 @@ public class ProspectInterestService {
                 .stream()
                 .filter(prospectInterest -> prospectInterest.getInterest().getId().equals(prospectInterestDetails.getInterestId()))
                 .findFirst();
+        UserEntity user = this.authenticationService.getCurrentUser();
 
         if (matchingProspectInterest.isPresent()) {
             // Update the existing ProspectInterest
             ProspectInterest prospectInterest = matchingProspectInterest.get();
             prospectInterest.setStatus(prospectInterestDetails.getStatus());
+            prospectInterest.setUpdatedAt(LocalDateTime.now());
+            prospectInterest.setUpdatedBy(user.getName());
             prospectRepository.save(prospect); // Save the updated Prospect entity
             return ProspectInterestDtoBuilder.fromEntity(prospectInterest);
         } else {
@@ -62,6 +68,8 @@ public class ProspectInterestService {
                     .name(newInterest.getName())
                     .prospect(prospect) // Use the existing Prospect entity
                     .status(prospectInterestDetails.getStatus())
+                    .createdAt(LocalDateTime.now())
+                    .createdBy(user.getName())
                     .build();
 
             // Save the new ProspectInterest and return it as a DTO

--- a/src/main/java/com/sales_scout/service/leads/ProspectService.java
+++ b/src/main/java/com/sales_scout/service/leads/ProspectService.java
@@ -113,6 +113,8 @@ public class ProspectService {
                  imagePath = null;
             }
 
+            UserEntity user = this.authenticationService.getCurrentUser();
+
             Prospect prospect;
 
             if (prospectRequestDto.getId() != null) {
@@ -150,6 +152,7 @@ public class ProspectService {
                     prospect.setReprosentaveJobTitle(prospectRequestDto.getReprosentaveJobTitle());
                     prospect.setLogo(imagePath != null && !imagePath.isEmpty() ? imagePath : "");
                     prospect.setUpdatedAt(LocalDateTime.now());
+                    prospect.setUpdatedBy(user.getName());
                 } else {
                     throw new RuntimeException("Prospect with ID " + prospectRequestDto.getId() + " not found.");
                 }
@@ -187,12 +190,11 @@ public class ProspectService {
                         .logo(imagePath)
                         .active(ActiveInactiveEnum.ACTIVE)
                         .company(Company.builder().id((long)1).build())
+                        .createdAt(LocalDateTime.now())
+                        .createdBy(user.getName())
                         .build();
             }
 
-
-           prospect.setCreatedAt(LocalDateTime.now());
-           prospect.setUpdatedAt(LocalDateTime.now());
 
             // Save the prospect entity
             return prospectRepository.save(prospect);
@@ -488,6 +490,8 @@ public class ProspectService {
         ProspectStatus oldStatus = prospect.getStatus(); // Save the old status for comparison
         prospect.setStatus(status);
 
+        UserEntity user = this.authenticationService.getCurrentUser();
+
         // Check if a customer already exists for this prospect
         Optional<Customer> customer = customerRepository.findByProspectIdAndDeletedAtIsNull(prospectId);
 
@@ -536,6 +540,7 @@ public class ProspectService {
                     addCustomer.setProspect(prospect);
                     addCustomer.setCompany(prospect.getCompany());
                     addCustomer.setCreatedAt(prospect.getCreatedAt());
+                    addCustomer.setCreatedBy(prospect.getCreatedBy());
                     // Save the new customer
                     this.customerRepository.save(addCustomer);
             }
@@ -545,6 +550,8 @@ public class ProspectService {
             // update status customer
             Customer updateCustomer = customer.get();
             updateCustomer.setStatus(status);
+            updateCustomer.setUpdatedAt(LocalDateTime.now());
+            updateCustomer.setUpdatedBy(user.getName());
             this.customerRepository.save(updateCustomer);
         }
         // Save the updated prospect


### PR DESCRIPTION
Implementation of BaseDto and Integration Across All Request/Response DTOs with Added Audit Fields in Mappers

Description
This PR introduces a BaseDto class to centralize common fields (createdAt, updatedAt, createdBy, updatedBy) across all DTOs. It ensures consistency and reduces code duplication by extending BaseDto in all Request and Response DTOs. Additionally, the mappers have been updated to include these fields during entity-DTO conversions.

Changes Introduced
Creation of BaseDto:

A new BaseDto class has been created to encapsulate common audit fields:

createdAt

updatedAt

createdBy

updatedBy

Integration of BaseDto Across All DTOs:

All Request and Response DTOs now extend BaseDto to inherit the common fields.

This ensures consistency and reduces redundancy in DTO definitions.

Updates to Mappers:

Mappers have been updated to include the BaseDto fields during conversions between entities and DTOs.

This ensures that audit information is consistently mapped and available in the DTOs.